### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @Vulcanit3 @ChristianWitts


### PR DESCRIPTION
For the purpose of auto-adding reviewers to Pull Requests.
For now it's the two people with push access, myself and John.

Signed-off-by: Christian Witts <cwitts@gmail.com>